### PR TITLE
chore: add collaboration and release templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Report a reproducible problem.
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Run ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: Docker/PVE/LXC OS, browser, subnet size, nmap version
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Remove secrets, public IPs, and private network exports before posting.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: MVP Scope
+    url: https://github.com/zshleon/home-topology-mapper/blob/main/TASKS.md
+    about: Check the current MVP task list before proposing larger features.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest an MVP-compatible enhancement.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem would this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the smallest useful version.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - scanning
+        - device inventory
+        - topology editor
+        - persistence
+        - Docker/LXC
+        - documentation
+        - other
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This does not require cloud sync, multi-user auth, SNMP deep discovery, alerting, or enterprise NMS features.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,24 @@
+name: Task
+description: Track a concrete engineering task.
+title: "chore: "
+labels: ["task"]
+body:
+  - type: input
+    id: task
+    attributes:
+      label: TASKS.md item
+      placeholder: scan-nmap-mvp
+    validations:
+      required: true
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+      placeholder: List the expected files or behavior changes.
+    validations:
+      required: true
+  - type: textarea
+    id: checks
+    attributes:
+      label: Checks
+      placeholder: How should this be verified?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Task
+
+Closes or implements: `TASKS.md` task name here
+
+## Summary
+
+- 
+
+## Changes
+
+- 
+
+## Test Plan
+
+- [ ] Backend checks run
+- [ ] Frontend build run
+- [ ] Docker build considered or run
+- [ ] Manual UI check, if frontend behavior changed
+
+## Compatibility
+
+- [ ] Does not overwrite manual topology edges
+- [ ] Does not require database migration
+- [ ] Does not change Docker/LXC permissions
+
+## Notes
+
+Anything reviewers or AI collaborators should know.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install backend
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Compile backend
+        working-directory: backend
+        run: python -m compileall app
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t home-topology-mapper:ci .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,30 @@ Home Topology Mapper is expected to be developed by a single maintainer working 
 6. Manual topology data must always have priority over scan results.
 7. Never introduce cloud sync, auth, SNMP, alerting, or enterprise features into MVP tasks unless `TASKS.md` is updated first.
 
+## Coordination
+
+- Codex and Antigravity should not work on the same task branch at the same time.
+- If a task changes scope, update `TASKS.md` in the same PR.
+- If a task touches scan behavior, explicitly note how manual topology data is protected.
+- If a task changes Docker/LXC behavior, update `README.md` or `docs/ARCHITECTURE.md`.
+
+## Required Checks
+
+Backend:
+
+```bash
+cd backend
+python -m compileall app
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
 ## Commit Format
 
 Use:
@@ -31,4 +55,3 @@ Every PR should include:
 - Changed files
 - Test plan
 - Compatibility / migration notes
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Home Topology Mapper is developed in small, reviewable tasks. The MVP should stay focused on discovery, topology editing, persistence, and Docker/LXC fit.
+
+## Workflow
+
+1. Read `TASKS.md`.
+2. Pick one unchecked task.
+3. Create a branch named `feature/<task-name>`.
+4. Keep the change scoped to that task.
+5. Open a pull request with the template filled in.
+
+## Local Checks
+
+Backend:
+
+```bash
+cd backend
+python -m venv .venv
+. .venv/bin/activate
+pip install -e ".[dev]"
+python -m compileall app
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
+Docker:
+
+```bash
+docker build -t home-topology-mapper:local .
+```
+
+## Design Rules
+
+- Manual topology edges and user-confirmed layout have the highest priority.
+- Scans may update inventory and status, but must not overwrite confirmed manual links.
+- Keep the UI lightweight, modern, and screenshot-friendly.
+- Do not add multi-user auth, cloud sync, SNMP deep discovery, alerting, or enterprise NMS features during MVP work unless `TASKS.md` is updated first.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is not an enterprise NMS. The goal is:
 ## Quick Start
 
 ```bash
-git clone https://github.com/your-name/home-topology-mapper.git
+git clone https://github.com/zshleon/home-topology-mapper.git
 cd home-topology-mapper
 cp .env.example .env
 # Edit HTM_SCAN_SUBNETS in .env, for example: HTM_SCAN_SUBNETS=10.0.0.0/24
@@ -42,6 +42,8 @@ The default `docker-compose.yml` already does this.
 
 ## Development
 
+Start with `TASKS.md` and keep one task per branch.
+
 Backend:
 
 ```bash
@@ -62,7 +64,13 @@ npm run dev
 
 The frontend dev server expects the API at `http://localhost:8080` by default.
 
+## Collaboration
+
+- `AGENTS.md` defines AI collaboration rules for Codex and Antigravity.
+- `docs/ANTIGRAVITY_HANDOFF.md` is the handoff note for a second AI agent.
+- `CONTRIBUTING.md` lists local checks and MVP scope boundaries.
+- `.github/pull_request_template.md` keeps pull requests reviewable.
+
 ## Project Status
 
 This is an MVP scaffold. The first production milestone is to make scanning, editing, and persistence solid before adding SNMP, auth, alerting, or cloud features.
-

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+Home Topology Mapper is intended for trusted home and homelab networks. It scans private LAN ranges and stores local topology data in SQLite.
+
+## Supported Versions
+
+The project is pre-1.0. Security fixes target the current `main` branch until the first tagged release.
+
+## Reporting Issues
+
+Please open a private report with the maintainer when possible, or file a GitHub issue without including secrets, public IPs, tokens, passwords, or full network exports.
+
+## Security Notes
+
+- Do not expose the app directly to the public internet.
+- Run behind a trusted VPN or reverse proxy if remote access is needed.
+- The Docker Compose configuration uses host networking and raw network capabilities for LAN discovery. Review this before deploying on shared hosts.
+- Do not commit scan exports, SQLite databases, or `.env` files.

--- a/TASKS.md
+++ b/TASKS.md
@@ -30,5 +30,4 @@ This project uses small, reviewable branches. Pick exactly one task per branch u
 
 - [ ] `lxc-permission-checks`: Add startup diagnostics for nmap, NET_RAW, host networking, and subnet reachability.
 - [ ] `compose-production-polish`: Add healthcheck, labels, and documented env vars.
-- [ ] `release-template`: Add GitHub release checklist and versioning.
-
+- [x] `release-template`: Add GitHub release checklist and versioning.

--- a/docs/ANTIGRAVITY_HANDOFF.md
+++ b/docs/ANTIGRAVITY_HANDOFF.md
@@ -1,0 +1,72 @@
+# Antigravity Handoff
+
+You are collaborating on Home Topology Mapper with Codex and the maintainer.
+
+## Project Goal
+
+Build a lightweight home and homelab LAN topology mapper:
+
+- discover devices on a private subnet
+- infer IP, MAC, hostname, vendor, and rough device type
+- generate an initial topology draft
+- let the user drag nodes and manually connect devices
+- preserve manual topology across future scans
+
+This is not an enterprise NMS.
+
+## Before Editing
+
+1. Read `README.md`.
+2. Read `TASKS.md`.
+3. Read `AGENTS.md`.
+4. Pick exactly one unchecked task.
+5. Create a branch named `feature/<task-name>`.
+
+## Hard Rules
+
+- Manual topology edges always win over scan output.
+- Do not overwrite confirmed manual relationships during incremental scans.
+- Keep MVP scope tight.
+- Do not add auth, cloud sync, SNMP deep discovery, alerting, traffic monitoring, or mobile apps unless `TASKS.md` changes first.
+- Do not commit `.env`, databases, scan exports, or private network data.
+
+## Useful Commands
+
+Backend:
+
+```bash
+cd backend
+pip install -e ".[dev]"
+python -m compileall app
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
+Docker:
+
+```bash
+docker compose up -d --build
+```
+
+## Suggested First Task
+
+Start with:
+
+```text
+scan-nmap-mvp
+```
+
+Expected work:
+
+- harden nmap discovery
+- improve quick/full scan behavior
+- keep scanner output small and structured
+- add clear error messages for missing nmap or permission issues
+
+Open a PR against `main` using `.github/pull_request_template.md`.

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -7,7 +7,7 @@ git init
 git add .
 git commit -m "chore: initialize home topology mapper"
 git branch -M main
-git remote add origin <repo-url>
+git remote add origin https://github.com/zshleon/home-topology-mapper.git
 git push -u origin main
 ```
 
@@ -32,3 +32,10 @@ Open a PR with:
 - test plan
 - compatibility notes
 
+## Current Remote
+
+```bash
+git remote add origin https://github.com/zshleon/home-topology-mapper.git
+```
+
+The GitHub repository should be created without a generated README, `.gitignore`, or license because this repository already contains them.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,56 @@
+# Release Guide
+
+Home Topology Mapper uses simple semantic versioning once tags start.
+
+## Versioning
+
+- `0.x.y`: MVP and pre-1.0 releases.
+- Patch version bumps should be bug fixes, docs, or small deployment improvements.
+- Minor version bumps can include new MVP features or notable UI/API behavior.
+
+## Release Checklist
+
+1. Confirm `main` is green in CI.
+2. Confirm `TASKS.md` accurately reflects completed work.
+3. Run local checks:
+
+   ```bash
+   cd frontend && npm ci && npm run build
+   cd ../backend && python -m compileall app
+   cd .. && docker build -t home-topology-mapper:release .
+   ```
+
+4. Update README if deployment steps or environment variables changed.
+5. Create and push a tag:
+
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+6. Draft a GitHub release with:
+
+   - What changed
+   - Upgrade notes
+   - Docker/LXC notes
+   - Known limitations
+
+## Pre-1.0 Release Notes Template
+
+```md
+## Highlights
+
+- 
+
+## Changes
+
+- 
+
+## Upgrade Notes
+
+- 
+
+## Known Limitations
+
+- 
+```


### PR DESCRIPTION
## Task

Implements `release-template` from `TASKS.md`.

## Summary

Set up GitHub collaboration infrastructure so Codex, Antigravity, and future contributors can work from small reviewable tasks.

## Changes

- Add GitHub pull request and issue templates.
- Add GitHub Actions CI for backend compile checks, frontend build, and Docker build.
- Add Dependabot configuration for npm, Python, and GitHub Actions.
- Add contribution and security guidance.
- Add release checklist and Antigravity handoff documentation.
- Update README, AGENTS, TASKS, and Git workflow docs.

## Test Plan

- Ran `npm run build` in `frontend`.
- Ran Python `compileall` against `backend/app`.
- Ran `git diff --check`.

## Compatibility

- Does not change runtime behavior.
- Does not alter database schema.
- Does not affect manual topology preservation logic.