### PR TITLE
feat: harden nmap scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The default `docker-compose.yml` already does this.
 
 ## MVP Features
 
-- Subnet scan through `nmap`
+- Subnet scan through `nmap` with quick and full modes
 - Device inventory with IP, MAC, hostname, vendor, type guess, online/offline state
 - Topology editor powered by React Flow
 - Node dragging and manual edge creation
@@ -39,6 +39,7 @@ The default `docker-compose.yml` already does this.
 - Incremental scans preserve manual topology
 - New devices are highlighted
 - Offline devices are dimmed
+- Scan failures keep a human-readable hint in the history record
 
 ## Development
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -45,6 +45,11 @@ class LinkType(str, Enum):
     unknown = "unknown"
 
 
+class ScanMode(str, Enum):
+    quick = "quick"
+    full = "full"
+
+
 class Device(SQLModel, table=True):
     id: str = Field(default_factory=new_id, primary_key=True)
     ip: str = Field(index=True)
@@ -90,11 +95,11 @@ class ScanRecord(SQLModel, table=True):
     started_at: datetime = Field(default_factory=now_utc, index=True)
     finished_at: datetime | None = Field(default=None, index=True)
     subnet: str
-    scan_mode: str = "quick"
+    scan_mode: ScanMode = Field(default=ScanMode.quick, index=True)
     result_summary: str | None = None
     discovered_count: int = 0
     new_count: int = 0
     online_count: int = 0
     offline_count: int = 0
     error: str | None = None
-
+    error_hint: str | None = None

--- a/backend/app/routers/scans.py
+++ b/backend/app/routers/scans.py
@@ -8,7 +8,7 @@ from app.db.session import get_session
 from app.models import Device, DeviceStatus, ScanRecord
 from app.schemas import ScanRecordRead, ScanStartRequest
 from app.services.inventory import upsert_scanned_devices
-from app.services.scanner import scan_subnet
+from app.services.scanner import ScanError, normalize_scan_mode, scan_subnet
 from app.services.topology import ensure_topology_for_devices, mark_offline_devices
 
 router = APIRouter(prefix="/api/scans", tags=["scans"])
@@ -25,7 +25,7 @@ def start_scan(
     session: Session = Depends(get_session),
 ) -> ScanRecord:
     subnet = payload.subnet or settings.subnet_list[0]
-    mode = payload.mode or settings.scan_mode
+    mode = normalize_scan_mode(payload.mode or settings.scan_mode)
     record = ScanRecord(subnet=subnet, scan_mode=mode)
     session.add(record)
     session.commit()
@@ -45,8 +45,22 @@ def start_scan(
             f"discovered={len(scanned)}, new={new_count}, online={record.online_count}, "
             f"marked_offline={offline_count}"
         )
+    except ScanError as exc:
+        record.error = str(exc)
+        record.error_hint = exc.hint
+        session.add(record)
+        session.commit()
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": exc.code,
+                "message": str(exc),
+                "hint": exc.hint,
+            },
+        ) from exc
     except Exception as exc:
         record.error = str(exc)
+        record.error_hint = "Check the backend logs for a full traceback."
         session.add(record)
         session.commit()
         raise HTTPException(status_code=500, detail=record.error) from exc
@@ -56,4 +70,3 @@ def start_scan(
         session.commit()
         session.refresh(record)
     return record
-

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from app.models import DeviceStatus, DeviceType, EdgeConfidence, LinkType
+from app.models import DeviceStatus, DeviceType, EdgeConfidence, LinkType, ScanMode
 
 
 class DeviceRead(BaseModel):
@@ -29,7 +29,7 @@ class DeviceUpdate(BaseModel):
 
 class ScanStartRequest(BaseModel):
     subnet: str | None = Field(default=None, examples=["192.168.1.0/24"])
-    mode: str | None = Field(default=None, examples=["quick", "full"])
+    mode: ScanMode | None = Field(default=None, examples=["quick", "full"])
 
 
 class ScanRecordRead(BaseModel):
@@ -37,13 +37,14 @@ class ScanRecordRead(BaseModel):
     started_at: datetime
     finished_at: datetime | None
     subnet: str
-    scan_mode: str
+    scan_mode: ScanMode
     result_summary: str | None
     discovered_count: int
     new_count: int
     online_count: int
     offline_count: int
     error: str | None
+    error_hint: str | None
 
 
 class TopologyNodeRead(BaseModel):
@@ -93,4 +94,3 @@ class TopologyRead(BaseModel):
 class TopologyWrite(BaseModel):
     nodes: list[TopologyNodeWrite]
     edges: list[TopologyEdgeWrite]
-

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -5,8 +5,7 @@ import shutil
 import subprocess
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
-
-from app.models import DeviceType
+from app.models import DeviceType, ScanMode
 
 
 QUICK_PORTS = [
@@ -35,6 +34,63 @@ QUICK_PORTS = [
 ]
 
 
+class ScanError(RuntimeError):
+    def __init__(self, code: str, message: str, hint: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.hint = hint
+
+
+def normalize_scan_mode(mode: str | ScanMode | None) -> ScanMode:
+    if isinstance(mode, ScanMode):
+        normalized = mode.value
+    else:
+        normalized = str(mode or ScanMode.quick.value).strip().lower()
+    if normalized not in {ScanMode.quick.value, ScanMode.full.value}:
+        raise ScanError(
+            "invalid_scan_mode",
+            f"Unsupported scan mode '{mode}'.",
+            "Choose either 'quick' or 'full'.",
+        )
+    return ScanMode(normalized)
+
+
+def _build_discovery_args(subnet: str) -> list[str]:
+    return ["-n", "-sn", subnet, "-oX", "-"]
+
+
+def _build_port_scan_args(mode: ScanMode, ips: list[str]) -> tuple[list[str], int]:
+    if mode == ScanMode.full:
+        return (
+            [
+                "-n",
+                "-Pn",
+                "-p-",
+                "--open",
+                "--max-retries",
+                "1",
+                "--min-rate",
+                "1500",
+                *ips,
+            ],
+            900,
+        )
+
+    return (
+        [
+            "-n",
+            "-Pn",
+            "-p",
+            ",".join(str(port) for port in QUICK_PORTS),
+            "--open",
+            "--max-retries",
+            "1",
+            *ips,
+        ],
+        240,
+    )
+
+
 @dataclass
 class ScannedDevice:
     ip: str
@@ -49,22 +105,57 @@ class ScannedDevice:
 
 def _run_nmap(args: list[str], timeout: int = 180) -> str:
     if shutil.which("nmap") is None:
-        raise RuntimeError("nmap is not installed in this container")
-    proc = subprocess.run(
-        ["nmap", *args],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        timeout=timeout,
-        check=False,
-    )
+        raise ScanError(
+            "nmap_missing",
+            "nmap is not installed in this container.",
+            "Install nmap inside the LXC or Docker image before scanning.",
+        )
+    try:
+        proc = subprocess.run(
+            ["nmap", *args],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ScanError(
+            "scan_timeout",
+            f"nmap timed out after {timeout} seconds.",
+            "Try quick mode first or narrow the subnet.",
+        ) from exc
+    stderr = proc.stderr.strip()
+    lower = stderr.lower()
+    if (
+        "requires root privileges" in lower
+        or "requires root" in lower
+        or "operation not permitted" in lower
+        or "raw sockets" in lower
+    ):
+        raise ScanError(
+            "permission_denied",
+            "nmap needs raw network privileges in this container.",
+            "Run the container with host networking and NET_RAW, then retry the scan.",
+        )
     if proc.returncode not in (0, 1):
-        raise RuntimeError(proc.stderr.strip() or "nmap failed")
+        raise ScanError(
+            "nmap_failed",
+            stderr or "nmap failed",
+            "Check the subnet, container networking, and nmap permissions.",
+        )
     return proc.stdout
 
 
 def _parse_discovery(xml_text: str) -> list[ScannedDevice]:
-    root = ET.fromstring(xml_text)
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ScanError(
+            "invalid_nmap_output",
+            "nmap discovery output could not be parsed.",
+            "Check that nmap is producing XML output and the target subnet is reachable.",
+        ) from exc
     devices: list[ScannedDevice] = []
     for host in root.findall("host"):
         status = host.find("status")
@@ -87,7 +178,14 @@ def _parse_discovery(xml_text: str) -> list[ScannedDevice]:
 
 
 def _parse_ports(xml_text: str) -> dict[str, list[int]]:
-    root = ET.fromstring(xml_text)
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ScanError(
+            "invalid_nmap_output",
+            "nmap port scan output could not be parsed.",
+            "Try quick mode or reduce the subnet size.",
+        ) from exc
     by_ip: dict[str, list[int]] = {}
     for host in root.findall("host"):
         ipv4 = host.find("address[@addrtype='ipv4']")
@@ -129,25 +227,20 @@ def _guess_type(device: ScannedDevice, subnet: str) -> tuple[DeviceType, bool]:
     return DeviceType.unknown, False
 
 
-def scan_subnet(subnet: str, mode: str = "quick") -> list[ScannedDevice]:
-    ipaddress.ip_network(subnet, strict=False)
-    discovery_xml = _run_nmap(["-sn", subnet, "-oX", "-"], timeout=180)
+def scan_subnet(subnet: str, mode: str | ScanMode = ScanMode.quick) -> list[ScannedDevice]:
+    network = ipaddress.ip_network(subnet, strict=False)
+    scan_mode = normalize_scan_mode(mode)
+    discovery_xml = _run_nmap(_build_discovery_args(network.with_prefixlen), timeout=180)
     devices = _parse_discovery(discovery_xml)
     if not devices:
         return []
 
     ips = [device.ip for device in devices]
-    if mode == "full":
-        port_args = ["-Pn", "-p-", "--open", "--max-retries", "1", "--min-rate", "1500"]
-        timeout = 900
-    else:
-        port_args = ["-Pn", "-p", ",".join(str(port) for port in QUICK_PORTS), "--open"]
-        timeout = 240
-    port_xml = _run_nmap([*port_args, "-oX", "-", *ips], timeout=timeout)
+    port_args, timeout = _build_port_scan_args(scan_mode, ips)
+    port_xml = _run_nmap([*port_args, "-oX", "-"], timeout=timeout)
     ports_by_ip = _parse_ports(port_xml)
 
     for device in devices:
         device.ports = ports_by_ip.get(device.ip, [])
         device.device_type, device.is_network_node = _guess_type(device, subnet)
     return devices
-

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,3 +27,5 @@ packages = ["app"]
 line-length = 100
 target-version = "py311"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -1,0 +1,81 @@
+from app.models import DeviceType, ScanMode
+from app.services import scanner
+
+
+DISCOVERY_XML = """<?xml version=\"1.0\"?>
+<nmaprun>
+  <host>
+    <status state=\"up\"/>
+    <address addr=\"10.0.0.1\" addrtype=\"ipv4\"/>
+    <address addr=\"aa:bb:cc:dd:ee:ff\" addrtype=\"mac\" vendor=\"TP-Link\"/>
+    <hostnames>
+      <hostname name=\"router.local\"/>
+    </hostnames>
+  </host>
+</nmaprun>
+"""
+
+
+PORT_XML = """<?xml version=\"1.0\"?>
+<nmaprun>
+  <host>
+    <address addr=\"10.0.0.1\" addrtype=\"ipv4\"/>
+    <ports>
+      <port portid=\"53\"><state state=\"open\"/></port>
+      <port portid=\"80\"><state state=\"open\"/></port>
+      <port portid=\"443\"><state state=\"open\"/></port>
+    </ports>
+  </host>
+</nmaprun>
+"""
+
+
+def test_normalize_scan_mode_rejects_invalid_value() -> None:
+    try:
+        scanner.normalize_scan_mode("fast")
+    except scanner.ScanError as exc:
+        assert exc.code == "invalid_scan_mode"
+    else:
+        raise AssertionError("Expected ScanError for invalid mode")
+
+
+def test_scan_subnet_quick_mode_builds_expected_commands(monkeypatch) -> None:
+    calls: list[tuple[list[str], int]] = []
+
+    def fake_run_nmap(args: list[str], timeout: int = 180) -> str:
+        calls.append((args, timeout))
+        if "-sn" in args:
+            return DISCOVERY_XML
+        return PORT_XML
+
+    monkeypatch.setattr(scanner, "_run_nmap", fake_run_nmap)
+
+    devices = scanner.scan_subnet("10.0.0.0/24", mode=ScanMode.quick)
+
+    assert len(calls) == 2
+    assert calls[0][0][:3] == ["-n", "-sn", "10.0.0.0/24"]
+    assert calls[1][0][0:4] == ["-n", "-Pn", "-p", ",".join(str(port) for port in scanner.QUICK_PORTS)]
+    assert calls[1][1] == 240
+    assert len(devices) == 1
+    assert devices[0].ip == "10.0.0.1"
+    assert devices[0].device_type == DeviceType.router
+    assert devices[0].is_network_node is True
+    assert devices[0].ports == [53, 80, 443]
+
+
+def test_scan_subnet_full_mode_uses_full_port_range(monkeypatch) -> None:
+    calls: list[tuple[list[str], int]] = []
+
+    def fake_run_nmap(args: list[str], timeout: int = 180) -> str:
+        calls.append((args, timeout))
+        if "-sn" in args:
+            return DISCOVERY_XML
+        return PORT_XML
+
+    monkeypatch.setattr(scanner, "_run_nmap", fake_run_nmap)
+
+    scanner.scan_subnet("10.0.0.0/24", mode="full")
+
+    assert len(calls) == 2
+    assert "-p-" in calls[1][0]
+    assert calls[1][1] == 900

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,13 @@
 
 Returns a `ScanRecord`.
 
+Accepted scan modes:
+
+- `quick`: common home-homelab ports only
+- `full`: scan all TCP ports, slower but more exhaustive
+
+On failure, the scan history record also stores `error_hint` for operator guidance.
+
 ## Scan History
 
 `GET /api/scans`
@@ -71,4 +78,3 @@ Returns nodes with embedded device records and edges.
   ]
 }
 ```
-

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,7 +9,33 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     ...init
   });
   if (!response.ok) {
-    const message = await response.text();
+    const contentType = response.headers.get("content-type") ?? "";
+    let message = response.statusText;
+    if (contentType.includes("application/json")) {
+      try {
+        const data = await response.json() as { detail?: unknown; message?: unknown };
+        if (typeof data.detail === "string") {
+          message = data.detail;
+        } else if (data.detail && typeof data.detail === "object") {
+          const detail = data.detail as { message?: unknown; hint?: unknown; code?: unknown };
+          const parts = [
+            typeof detail.code === "string" ? detail.code : null,
+            typeof detail.message === "string" ? detail.message : null,
+            typeof detail.hint === "string" ? detail.hint : null
+          ].filter(Boolean);
+          message = parts.join("\n");
+        } else if (typeof data.message === "string") {
+          message = data.message;
+        } else {
+          message = JSON.stringify(data);
+        }
+      } catch {
+        message = await response.text();
+      }
+    } else {
+      const text = await response.text();
+      message = text || message;
+    }
     throw new Error(message || response.statusText);
   }
   return response.json() as Promise<T>;
@@ -26,4 +52,3 @@ export const api = {
   saveTopology: (payload: unknown) =>
     request<Topology>("/api/topology", { method: "PUT", body: JSON.stringify(payload) })
 };
-

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -117,7 +117,8 @@ export default function Dashboard({ onOpenTopology }: DashboardProps) {
             {scans.slice(0, 4).map((scan) => (
               <div key={scan.id} className="rounded-lg border border-slate-100 p-3">
                 <p className="font-medium">{scan.subnet}</p>
-                <p className="text-sm text-slate-500">{scan.result_summary || scan.error || "No summary yet"}</p>
+                <p className="text-sm text-slate-500 whitespace-pre-line">{scan.result_summary || scan.error || "No summary yet"}</p>
+                {scan.error_hint && <p className="mt-1 text-xs text-slate-400 whitespace-pre-line">{scan.error_hint}</p>}
               </div>
             ))}
             {scans.length === 0 && <p className="text-sm text-slate-500">No scans yet.</p>}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -34,13 +34,14 @@ export interface ScanRecord {
   started_at: string;
   finished_at: string | null;
   subnet: string;
-  scan_mode: string;
+  scan_mode: "quick" | "full";
   result_summary: string | null;
   discovered_count: number;
   new_count: number;
   online_count: number;
   offline_count: number;
   error: string | null;
+  error_hint: string | null;
 }
 
 export interface TopologyNode {
@@ -67,4 +68,3 @@ export interface Topology {
   nodes: TopologyNode[];
   edges: TopologyEdge[];
 }
-


### PR DESCRIPTION
## Task

Implements `scan-nmap-mvp` from `TASKS.md`.

Closes #2 on merge.

## Summary

Harden the scan pipeline so LAN discovery is more reliable in Docker/LXC and easier to understand when it fails.

## Changes

- Add explicit quick/full scan mode normalization.
- Add `nmap` command builders with `-n` and profile-specific port ranges.
- Add structured scan errors for missing nmap, permission issues, parse failures, and timeouts.
- Store `error_hint` on scan history records.
- Improve API client error parsing so backend hints surface in the UI.
- Show scan hints in the dashboard history cards.
- Add scanner unit tests for mode validation and command construction.

## Test Plan

- Ran `python -m compileall backend/app`.
- Ran `pytest backend/tests`.
- Ran `npm run build` in `frontend`.
- Ran `git diff --check`.

## Compatibility

- Does not change topology persistence behavior.
- Does not overwrite manual edges.
- Adds a new optional scan history field (`error_hint`).