### PR TITLE
feat: improve scan error display

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -11,7 +11,7 @@ This project uses small, reviewable branches. Pick exactly one task per branch u
 - [ ] `scan-nmap-mvp`: Harden nmap discovery and quick/full scan modes.
 - [ ] `device-identity-merge`: Improve MAC-first identity matching and IP-change handling.
 - [ ] `device-type-heuristics`: Expand home-device type guessing rules and make them configurable.
-- [ ] `scan-error-ui`: Show scan errors and permission hints clearly in the dashboard.
+- [/] `scan-error-ui`: Show scan errors and permission hints clearly in the dashboard.
 
 ## Phase 3 - Topology Editor
 

--- a/backend/app/routers/scans.py
+++ b/backend/app/routers/scans.py
@@ -46,10 +46,25 @@ def start_scan(
             f"marked_offline={offline_count}"
         )
     except Exception as exc:
-        record.error = str(exc)
+        error_msg = str(exc)
+        hint = "An unexpected error occurred during scanning."
+        
+        if "nmap is not installed" in error_msg:
+            hint = "Nmap is missing. Please install it in the container (e.g., apk add nmap or apt-get install nmap)."
+        elif "Operation not permitted" in error_msg or "NET_RAW" in error_msg:
+            hint = "Permission denied. Nmap requires root or NET_RAW capabilities. In LXC/Docker, check host networking or privileged mode."
+        elif "timed out" in error_msg.lower():
+            hint = "Scan timed out. The network might be too large or slow. Try a smaller range or 'quick' mode."
+        elif "failed" in error_msg.lower():
+            hint = "Scan failed. Check if the target subnet is reachable from this host."
+
+        record.error = f"{error_msg} | HINT: {hint}"
         session.add(record)
         session.commit()
-        raise HTTPException(status_code=500, detail=record.error) from exc
+        raise HTTPException(
+            status_code=500, 
+            detail={"message": error_msg, "hint": hint}
+        ) from exc
     finally:
         record.finished_at = datetime.now(UTC)
         session.add(record)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,8 +9,18 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     ...init
   });
   if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || response.statusText);
+    let detail: any = await response.text();
+    try {
+      detail = JSON.parse(detail);
+    } catch {
+      // Not JSON
+    }
+    const message = typeof detail === "object" ? (detail.detail?.message || detail.detail || "Request failed") : detail;
+    const hint = typeof detail === "object" ? detail.detail?.hint : undefined;
+    
+    const error = new Error(message);
+    (error as any).hint = hint;
+    throw error;
   }
   return response.json() as Promise<T>;
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { GitFork, Radar, RefreshCw } from "lucide-react";
+import { AlertTriangle, GitFork, Radar, RefreshCw } from "lucide-react";
 import { api } from "../api/client";
 import type { Device, ScanRecord } from "../types";
 
@@ -13,7 +13,7 @@ export default function Dashboard({ onOpenTopology }: DashboardProps) {
   const [subnet, setSubnet] = useState("");
   const [mode, setMode] = useState("quick");
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string; hint?: string } | null>(null);
 
   const refresh = async () => {
     const [deviceData, scanData] = await Promise.all([api.devices(), api.scans()]);
@@ -22,7 +22,7 @@ export default function Dashboard({ onOpenTopology }: DashboardProps) {
   };
 
   useEffect(() => {
-    refresh().catch((err) => setError(String(err)));
+    refresh().catch((err) => setError({ message: String(err) }));
   }, []);
 
   const stats = useMemo(() => {
@@ -39,7 +39,10 @@ export default function Dashboard({ onOpenTopology }: DashboardProps) {
       await api.startScan({ subnet: subnet || undefined, mode });
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError({ 
+        message: err instanceof Error ? err.message : String(err),
+        hint: (err as any).hint
+      });
     } finally {
       setLoading(false);
     }
@@ -102,7 +105,21 @@ export default function Dashboard({ onOpenTopology }: DashboardProps) {
               {loading ? "Scanning" : "Scan"}
             </button>
           </div>
-          {error && <p className="mt-3 rounded-lg bg-rose-50 p-3 text-sm text-rose-700">{error}</p>}
+          {error && (
+            <div className="mt-4 rounded-lg border border-rose-200 bg-rose-50 p-4">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-rose-600" />
+                <div>
+                  <p className="font-semibold text-rose-800">{error.message}</p>
+                  {error.hint && (
+                    <p className="mt-1 text-sm text-rose-700 leading-relaxed">
+                      <span className="font-medium">Hint:</span> {error.hint}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-soft">
@@ -114,10 +131,22 @@ export default function Dashboard({ onOpenTopology }: DashboardProps) {
             </button>
           </div>
           <div className="space-y-3">
-            {scans.slice(0, 4).map((scan) => (
-              <div key={scan.id} className="rounded-lg border border-slate-100 p-3">
-                <p className="font-medium">{scan.subnet}</p>
-                <p className="text-sm text-slate-500">{scan.result_summary || scan.error || "No summary yet"}</p>
+            {scans.slice(0, 5).map((scan) => (
+              <div 
+                key={scan.id} 
+                className={`rounded-lg border p-3 ${scan.error ? "border-rose-100 bg-rose-50/30" : "border-slate-100"}`}
+              >
+                <div className="flex items-center justify-between">
+                  <p className="font-medium">{scan.subnet}</p>
+                  {scan.error && (
+                    <span className="rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold uppercase text-rose-700">
+                      Failed
+                    </span>
+                  )}
+                </div>
+                <p className={`text-sm mt-1 ${scan.error ? "text-rose-600" : "text-slate-500"}`}>
+                  {scan.error ? (scan.error.split("|")[1]?.replace("HINT:", "").trim() || scan.error) : (scan.result_summary || "No summary")}
+                </p>
               </div>
             ))}
             {scans.length === 0 && <p className="text-sm text-slate-500">No scans yet.</p>}


### PR DESCRIPTION
## Task
Closes or implements: `scan-error-ui`

## Summary
Improved the scan error display on the Dashboard to provide clear, actionable feedback when network discovery fails.

## Changes
- **Backend Enhancement**: Updated `scans.py` to categorize common scanning errors (nmap missing, permission denied, timeouts) and provide a descriptive `error_hint` alongside the raw error message.
- **API Client Refinement**: Updated `api/client.ts` to parse structured JSON error responses, allowing the UI to access specific error details and hints.
- **Dashboard UI Improvements**:
    - Added a structured alert box for scan failures, displaying both the main error and the provided hint.
    - Enhanced the 'Recent scans' list to highlight failed scans with a 'Failed' badge and a red background/border.
    - Integrated the `AlertTriangle` icon from Lucide for better visual warning.
- **User Hints**: Added specific guidance for common homelab issues:
    - LXC/Docker permission (NET_RAW) hints.
    - Nmap installation instructions.
    - Network timeout/scale suggestions.

## Test Plan
- [x] Backend checks run (`python -m compileall app` passed)
- [x] Frontend build run (`npm run build` passed)
- [x] Manual verification of UI layout and error styling.

## Compatibility
- [x] Does not overwrite manual topology edges
- [x] Does not require database migration
- [x] Does not change Docker/LXC permissions

## Notes
The error display is designed to be persistent on the Dashboard after a failure, ensuring the user can read the hint and take action before trying again.
