### PR TITLE
feat: add unclassified device bin

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -23,7 +23,7 @@ This project uses small, reviewable branches. Pick exactly one task per branch u
 ## Phase 4 - Persistence And Incremental Scans
 
 - [ ] `preserve-manual-edges`: Add tests proving scans cannot overwrite confirmed manual edges.
-- [ ] `new-device-bin`: Place newly discovered devices in a visible unclassified area.
+- [/] `new-device-bin`: Place newly discovered devices in a visible unclassified area.
 - [ ] `offline-device-policy`: Add configurable offline retention and visual style.
 
 ## Phase 5 - Docker And LXC Fit

--- a/backend/app/services/topology.py
+++ b/backend/app/services/topology.py
@@ -28,18 +28,34 @@ def initial_position(index: int, total: int, is_network_node: bool) -> tuple[flo
 
 def ensure_topology_for_devices(session: Session) -> None:
     devices = session.exec(select(Device).order_by(Device.ip)).all()
-    existing_nodes = {node.device_id: node for node in session.exec(select(TopologyNode)).all()}
+    # Get all current nodes to detect if this is an incremental discovery
+    all_nodes = session.exec(select(TopologyNode)).all()
+    existing_device_ids = {node.device_id for node in all_nodes}
+    is_incremental = len(existing_device_ids) > 0
 
     network_index = 0
     endpoint_index = 0
-    for device in sorted(devices, key=lambda item: ip_key(item.ip)):
-        if device.id not in existing_nodes:
-            if device.is_network_node:
-                x, y = initial_position(network_index, len(devices), True)
-                network_index += 1
+    new_discovery_index = 0
+
+    # Stable sort to keep initial indices consistent
+    sorted_devices = sorted(devices, key=lambda item: ip_key(item.ip))
+
+    for device in sorted_devices:
+        if device.id not in existing_device_ids:
+            if is_incremental:
+                # NEW DEVICE BIN: Column on the left (negative X)
+                x = -400
+                y = 120 + new_discovery_index * 160
+                new_discovery_index += 1
             else:
-                x, y = initial_position(endpoint_index, len(devices), False)
-                endpoint_index += 1
+                # First scan: Use normal grid/row layout
+                if device.is_network_node:
+                    x, y = initial_position(network_index, len(devices), True)
+                    network_index += 1
+                else:
+                    x, y = initial_position(endpoint_index, len(devices), False)
+                    endpoint_index += 1
+            
             session.add(TopologyNode(device_id=device.id, x=x, y=y, pinned=False))
 
     session.flush()

--- a/backend/tests/test_new_device_bin.py
+++ b/backend/tests/test_new_device_bin.py
@@ -1,0 +1,66 @@
+import pytest
+from sqlmodel import Session, create_engine, SQLModel, select
+from app.models import Device, DeviceStatus, DeviceType, TopologyNode
+from app.services.topology import ensure_topology_for_devices
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+def test_new_device_placed_in_bin_on_incremental_scan(session: Session):
+    # Setup: First scan with one device
+    device_1 = Device(id="d1", ip="10.0.0.1", device_type=DeviceType.router, status=DeviceStatus.online)
+    session.add(device_1)
+    session.commit()
+    
+    ensure_topology_for_devices(session)
+    
+    node_1 = session.exec(select(TopologyNode).where(TopologyNode.device_id == "d1")).one()
+    # First scan node should be in normal area (x >= 0)
+    assert node_1.x >= 0
+    
+    # Setup: Second device discovered later
+    device_2 = Device(id="d2", ip="10.0.0.2", device_type=DeviceType.pc, status=DeviceStatus.online)
+    session.add(device_2)
+    session.commit()
+    
+    ensure_topology_for_devices(session)
+    
+    node_2 = session.exec(select(TopologyNode).where(TopologyNode.device_id == "d2")).one()
+    # New device in incremental scan should be in the bin (x < 0)
+    assert node_2.x < 0
+    
+    # Old device should NOT have moved
+    session.refresh(node_1)
+    assert node_1.x >= 0
+
+def test_manual_position_preserved(session: Session):
+    # Setup: First scan
+    device_1 = Device(id="d1", ip="10.0.0.1", device_type=DeviceType.router, status=DeviceStatus.online)
+    session.add(device_1)
+    session.commit()
+    ensure_topology_for_devices(session)
+    
+    node_1 = session.exec(select(TopologyNode).where(TopologyNode.device_id == "d1")).one()
+    original_x = node_1.x
+    
+    # Manual move
+    node_1.x = 1337
+    node_1.y = 1337
+    session.add(node_1)
+    session.commit()
+    
+    # New device discovered
+    device_2 = Device(id="d2", ip="10.0.0.2", device_type=DeviceType.pc, status=DeviceStatus.online)
+    session.add(device_2)
+    session.commit()
+    
+    ensure_topology_for_devices(session)
+    
+    # Check node_1 position
+    session.refresh(node_1)
+    assert node_1.x == 1337
+    assert node_1.y == 1337

--- a/frontend/src/pages/TopologyPage.tsx
+++ b/frontend/src/pages/TopologyPage.tsx
@@ -13,9 +13,16 @@ import { Save, RefreshCw } from "lucide-react";
 import { api } from "../api/client";
 import type { Topology } from "../types";
 
-function nodeStyle(status: string, isNew: boolean) {
+function nodeStyle(status: string, isNew: boolean, isUnclassified: boolean) {
   if (status === "offline") {
     return { opacity: 0.45, border: "1px solid #cbd5e1", background: "#f8fafc" };
+  }
+  if (isUnclassified) {
+    return { 
+      border: "2px dashed #0891b2", 
+      background: "#ecfeff",
+      borderRadius: "12px",
+    };
   }
   if (isNew) {
     return { border: "2px solid #06b6d4", background: "#ecfeff" };
@@ -35,20 +42,26 @@ export default function TopologyPage() {
     const latestSeen = data.nodes.reduce((max, node) => Math.max(max, Date.parse(node.device.last_seen)), 0);
     const flowNodes: Node[] = data.nodes.map((node) => {
       const isNew = Date.parse(node.device.first_seen) === latestSeen || Date.parse(node.device.last_seen) === latestSeen;
+      const isUnclassified = node.x < -100;
       const title = node.custom_label || node.device.hostname || node.device.ip;
       return {
         id: node.device_id,
         position: { x: node.x, y: node.y },
         data: {
           label: (
-            <div className="min-w-[150px]">
+            <div className="relative min-w-[150px] p-1">
+              {isUnclassified && (
+                <div className="absolute -top-6 left-0 text-[10px] font-bold uppercase text-cyan-600">
+                  New / Unclassified
+                </div>
+              )}
               <div className="font-semibold">{title}</div>
               <div className="font-mono text-xs text-slate-500">{node.device.ip}</div>
-              <div className="mt-1 text-xs text-slate-500">{node.device.device_type}</div>
+              <div className="mt-1 text-xs text-slate-500 uppercase">{node.device.device_type}</div>
             </div>
           )
         },
-        style: nodeStyle(node.device.status, isNew)
+        style: nodeStyle(node.device.status, isNew, isUnclassified)
       };
     });
     const flowEdges: Edge[] = data.edges.map((edge) => ({


### PR DESCRIPTION
## Task
Closes or implements: `new-device-bin`

## Summary
Implemented a "New Device Bin" (Unclassified area) to handle incremental discovery without cluttering established topology layouts.

## Changes
- **Backend Logic (`topology.py`)**:
    - Updated `ensure_topology_for_devices` to distinguish between a "first scan" and subsequent "incremental discoveries".
    - For incremental scans, brand new devices are assigned coordinates in a vertical column on the left (starting at `x=-400`), serving as an "Inbox" for manual classification.
    - Preserved existing layout logic for previously discovered nodes; they remain at their manual or initial positions.
- **Frontend UI (`TopologyPage.tsx`)**:
    - Enhanced node styling for unclassified devices (dashed border, cyan background).
    - Added a "New / Unclassified" badge/label that appears above nodes in the bin area.
    - Improved typography and case formatting in node labels.
- **Unit Tests**:
    - Added `backend/tests/test_new_device_bin.py` covering:
        - Correct placement of new devices in the bin during incremental scans.
        - Non-movement of existing/manually positioned nodes.

## Test Plan
- [x] Backend checks run (`python -m compileall app` passed)
- [x] Frontend build run (`npm run build` passed)
- [x] Backend tests passed (New preservation and bin placement tests)

## Compatibility
- [x] Does not overwrite manual topology edges
- [x] Does not require database migration
- [x] Does not change Docker/LXC permissions

## Notes
The "Unclassified Bin" at `x < 0` provides a clear visual signal to users that new devices have been found and require their attention to be integrated into the main topology.
