### PR TITLE
feat: add topology node editor

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -15,7 +15,7 @@ This project uses small, reviewable branches. Pick exactly one task per branch u
 
 ## Phase 3 - Topology Editor
 
-- [ ] `topology-node-editor`: Add node label/icon editing inside the topology page.
+- [/] `topology-node-editor`: Add node label/icon editing inside the topology page.
 - [ ] `topology-edge-editor`: Let users choose ethernet/wifi/unknown per edge.
 - [ ] `topology-delete-link`: Add explicit edge deletion UX.
 - [ ] `topology-screenshot-mode`: Add a clean screenshot/share view.

--- a/frontend/src/pages/TopologyPage.tsx
+++ b/frontend/src/pages/TopologyPage.tsx
@@ -9,49 +9,86 @@ import ReactFlow, {
   useEdgesState,
   useNodesState
 } from "reactflow";
-import { Save, RefreshCw } from "lucide-react";
+import { Save, RefreshCw, Server, Smartphone, Laptop, Printer, Wifi, Cpu, Camera, HelpCircle, X as CloseIcon } from "lucide-react";
 import { api } from "../api/client";
 import type { Topology } from "../types";
 
-function nodeStyle(status: string, isNew: boolean) {
-  if (status === "offline") {
-    return { opacity: 0.45, border: "1px solid #cbd5e1", background: "#f8fafc" };
-  }
-  if (isNew) {
-    return { border: "2px solid #06b6d4", background: "#ecfeff" };
-  }
-  return { border: "1px solid #dbe2ea", background: "#ffffff" };
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const ICONS: Record<string, any> = {
+  router: Wifi,
+  server: Server,
+  phone: Smartphone,
+  pc: Laptop,
+  printer: Printer,
+  iot: Cpu,
+  camera: Camera,
+  unknown: HelpCircle
+};
+
+function nodeStyle(status: string, isNew: boolean, isSelected: boolean) {
+  const base = status === "offline" 
+    ? { opacity: 0.45 } 
+    : { opacity: 1 };
+
+  return {
+    ...base,
+    border: isSelected 
+      ? "2px solid #0f172a" 
+      : isNew ? "2px solid #06b6d4" : "1px solid #dbe2ea",
+    background: "#ffffff",
+    borderRadius: "8px",
+    boxShadow: isSelected ? "0 0 0 2px rgba(15, 23, 42, 0.1)" : "none",
+    padding: 0,
+  };
 }
 
 export default function TopologyPage() {
   const [topology, setTopology] = useState<Topology | null>(null);
+  const [retentionDays, setRetentionDays] = useState(30);
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+
+  const selectedNode = useMemo(() => 
+    nodes.find(n => n.id === selectedNodeId), 
+    [nodes, selectedNodeId]
+  );
 
   const load = useCallback(async () => {
     const data = await api.topology();
     setTopology(data);
-    const latestSeen = data.nodes.reduce((max, node) => Math.max(max, Date.parse(node.device.last_seen)), 0);
+    const latestSeen = data.nodes.reduce((max: number, node) => Math.max(max, Date.parse(node.device.last_seen)), 0);
     const flowNodes: Node[] = data.nodes.map((node) => {
       const isNew = Date.parse(node.device.first_seen) === latestSeen || Date.parse(node.device.last_seen) === latestSeen;
+      const Icon = ICONS[node.icon || node.device.device_type] || ICONS.unknown;
+
       const title = node.custom_label || node.device.hostname || node.device.ip;
       return {
         id: node.device_id,
         position: { x: node.x, y: node.y },
+        selected: node.device_id === selectedNodeId,
         data: {
+          device: node.device,
+          customLabel: node.custom_label,
+          icon: node.icon,
           label: (
-            <div className="min-w-[150px]">
-              <div className="font-semibold">{title}</div>
-              <div className="font-mono text-xs text-slate-500">{node.device.ip}</div>
-              <div className="mt-1 text-xs text-slate-500">{node.device.device_type}</div>
+            <div className="relative flex items-center gap-3 min-w-[180px] p-3 text-left">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-slate-50">
+                <Icon className="h-5 w-5 text-slate-600" />
+              </div>
+              <div className="flex-1 overflow-hidden">
+                <div className="truncate font-semibold">{title}</div>
+                <div className="truncate font-mono text-[10px] text-slate-400">{node.device.ip}</div>
+              </div>
             </div>
           )
         },
-        style: nodeStyle(node.device.status, isNew)
+        style: nodeStyle(node.device.status, isNew, node.device_id === selectedNodeId)
       };
     });
-    const flowEdges: Edge[] = data.edges.map((edge) => ({
+    const flowEdges: Edge[] = data.edges.map((edge: any) => ({
       id: edge.id,
       source: edge.from_device_id,
       target: edge.to_device_id,
@@ -94,8 +131,8 @@ export default function TopologyPage() {
         device_id: node.id,
         x: node.position.x,
         y: node.position.y,
-        custom_label: existing?.custom_label ?? null,
-        icon: existing?.icon ?? null,
+        custom_label: node.data.customLabel,
+        icon: node.data.icon,
         pinned: true
       };
     });
@@ -112,6 +149,35 @@ export default function TopologyPage() {
     setTopology(saved);
     setMessage("Topology saved");
     await load();
+  };
+
+  const updateSelectedNode = (updates: { customLabel?: string; icon?: string }) => {
+    if (!selectedNodeId) return;
+    setNodes(nds => nds.map(n => {
+      if (n.id !== selectedNodeId) return n;
+      const nextData = { ...n.data, ...updates };
+      const Icon = ICONS[nextData.icon || nextData.device.device_type] || ICONS.unknown;
+      const title = nextData.customLabel || nextData.device.hostname || nextData.device.ip;
+      
+      return {
+        ...n,
+        data: {
+          ...nextData,
+          label: (
+            <div className="relative flex items-center gap-3 min-w-[180px] p-3 text-left">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-slate-50">
+                <Icon className="h-5 w-5 text-slate-600" />
+              </div>
+              <div className="flex-1 overflow-hidden">
+                <div className="truncate font-semibold">{title}</div>
+                <div className="truncate font-mono text-[10px] text-slate-400">{nextData.device.ip}</div>
+              </div>
+            </div>
+          )
+        },
+        style: nodeStyle(n.data.device.status, false, true)
+      };
+    }));
   };
 
   const counts = useMemo(() => ({ nodes: nodes.length, edges: edges.length }), [edges.length, nodes.length]);
@@ -135,18 +201,105 @@ export default function TopologyPage() {
         </div>
       </div>
       {message && <div className="rounded-lg bg-cyan-50 p-3 text-sm text-cyan-800">{message}</div>}
-      <div className="h-[720px] overflow-hidden rounded-lg border border-slate-200 bg-white shadow-soft">
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          fitView
-        >
-          <Background />
-          <Controls />
-        </ReactFlow>
+      <div className="grid gap-5 lg:grid-cols-[1fr_300px]">
+        <div className="relative h-[720px] overflow-hidden rounded-lg border border-slate-200 bg-white shadow-soft">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            onNodeClick={(_, node) => {
+              setSelectedNodeId(node.id);
+              setNodes(nds => nds.map(n => ({
+                ...n,
+                selected: n.id === node.id,
+                style: nodeStyle(n.data.device.status, false, n.id === node.id)
+              })));
+            }}
+            onPaneClick={() => {
+              setSelectedNodeId(null);
+              setNodes(nds => nds.map(n => ({
+                ...n,
+                selected: false,
+                style: nodeStyle(n.data.device.status, false, false)
+              })));
+            }}
+            fitView
+          >
+            <Background />
+            <Controls />
+          </ReactFlow>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-soft">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-semibold text-slate-700 text-lg">Node Properties</h3>
+            {selectedNodeId && (
+              <button onClick={() => setSelectedNodeId(null)} className="p-1 hover:bg-slate-100 rounded">
+                <CloseIcon className="h-4 w-4 text-slate-400" />
+              </button>
+            )}
+          </div>
+          
+          {selectedNode ? (
+            <div className="space-y-6">
+              <div>
+                <label className="text-xs font-bold uppercase tracking-wider text-slate-400">Custom Label</label>
+                <input 
+                  type="text"
+                  value={selectedNode.data.customLabel || ""}
+                  onChange={(e) => updateSelectedNode({ customLabel: e.target.value })}
+                  className="mt-1.5 w-full rounded-lg border border-slate-200 px-3 py-2 outline-none focus:border-slate-500"
+                  placeholder="e.g. Living Room TV"
+                />
+              </div>
+
+              <div>
+                <label className="text-xs font-bold uppercase tracking-wider text-slate-400">Icon</label>
+                <div className="mt-2 grid grid-cols-4 gap-2">
+                  {Object.entries(ICONS).map(([key, Icon]) => (
+                    <button
+                      key={key}
+                      onClick={() => updateSelectedNode({ icon: key })}
+                      className={`flex h-10 items-center justify-center rounded-lg border ${
+                        (selectedNode.data.icon || selectedNode.data.device.device_type) === key
+                          ? "border-slate-950 bg-slate-950 text-white"
+                          : "border-slate-100 bg-slate-50 text-slate-500 hover:border-slate-200"
+                      }`}
+                    >
+                      <Icon className="h-4 w-4" />
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="pt-4 border-t border-slate-50">
+                <div className="text-xs text-slate-400">
+                  <div className="flex justify-between py-1">
+                    <span>IP Address</span>
+                    <span className="font-mono">{selectedNode.data.device.ip}</span>
+                  </div>
+                  <div className="flex justify-between py-1">
+                    <span>MAC</span>
+                    <span className="font-mono text-[9px] uppercase">{selectedNode.data.device.mac || "Unknown"}</span>
+                  </div>
+                  <div className="flex justify-between py-1">
+                    <span>Status</span>
+                    <span className={selectedNode.data.device.status === "online" ? "text-emerald-600" : "text-rose-600"}>
+                      {selectedNode.data.device.status}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center h-[300px] text-slate-400 text-sm text-center px-4">
+              <Cpu className="h-10 w-10 mb-3 opacity-20" />
+              <p>Select a node on the map to edit its label and icon.</p>
+            </div>
+          )}
+        </div>
       </div>
       <p className="text-sm text-slate-500">{counts.nodes} nodes, {counts.edges} links</p>
     </div>


### PR DESCRIPTION
## Task
Closes or implements: `topology-node-editor`

## Summary
Implemented a lightweight node property editor in the Topology page, allowing users to customize device labels and icons directly on the map.

## Changes
- **Node Property Panel**: Added a side panel in `TopologyPage.tsx` that appears when a node is selected.
- **Custom Labels**: Users can now set a `custom_label` for any device. This label takes precedence over the hostname in the topology view.
- **Icon Selector**: Added a curated set of icons (Router, Server, Phone, PC, Printer, IoT, Camera) using Lucide-React. Users can manually override the automatically inferred device icon.
- **Immediate Feedback**: Changes to labels or icons are reflected on the canvas immediately.
- **Persistence**: Edits are persisted to the database via the existing `saveTopology` API.
- **Native Selection**: Integrated React Flow's native selection state with custom styling (dark border and shadow) to clearly identify the active node.
- **Device Details**: The property panel also displays read-only device information (IP, MAC, Status) for quick reference.

## Test Plan
- [x] Backend checks run (`python -m compileall app` passed)
- [x] Frontend build run (`npm run build` passed)
- [x] Manual verification:
    - Click node -> Panel appears.
    - Edit label -> Node on canvas updates.
    - Change icon -> Node on canvas updates.
    - Click Save -> Page reloads with saved data.
    - Click Pane -> Panel closes, node deselects.

## Compatibility
- [x] Does not overwrite manual topology edges
- [x] Does not require database migration
- [x] Does not change Docker/LXC permissions

## Notes
The editor maintains independence from other unmerged features (like the new device bin or offline policy) to avoid PR conflicts.
